### PR TITLE
Add an option to export a molecule to github 

### DIFF
--- a/dist/flowDraw.js
+++ b/dist/flowDraw.js
@@ -103,6 +103,7 @@ var availableTypes = {
     readme:        {creator: Readme, atomType: "Readme"},
     rotate:        {creator: Rotate, atomType: "Rotate"},
     mirror:        {creator: Mirror, atomType: "Mirror"},
+    githubmolecule:{creator: GitHubMolecule, atomType: "GitHubMolecule"},
     union:         {creator: Union, atomType: "Union"}
 }
 

--- a/dist/index.html
+++ b/dist/index.html
@@ -93,6 +93,7 @@
     <script src="/js/molecules/scale.js"></script>
     <script src="/js/molecules/intersection.js"></script>
     <script src="/js/molecules/difference.js"></script>
+    <script src="/js/molecules/githubmolecule.js"></script>
     <script src="/circular-json.js"></script>
     <script src="/js/molecules/menu.js"></script>
     <script src="/flowDraw.js"></script>

--- a/dist/js/githubOauth.js
+++ b/dist/js/githubOauth.js
@@ -71,7 +71,7 @@ function showProjectsToLoad(){
                     accept: 'application/vnd.github.mercy-preview+json'
                 }
             }).then(data => {
-                if(data.data.names.includes("maslowcreate")){
+                if(data.data.names.includes("maslowcreate") || data.data.names.includes("maslowcreate-molecule")){
                     addProject(repo.name);
                 }
             })

--- a/dist/js/githubOauth.js
+++ b/dist/js/githubOauth.js
@@ -291,29 +291,4 @@ function loadProject(projectName){
     
 }
 
-function loadProjectByID(id){
-    //Get the repo by ID
-    
-    octokit.request('GET /repositories/:id', {id}).then(result => {
-        
-        //Find out the owners info;
-        
-        var user     = result.data.owner.login;
-        var repoName = result.data.name;
-        
-        //Get the file contents
-        
-        octokit.repos.getContents({
-            owner: user,
-            repo: repoName,
-            path: 'project.maslowcreate'
-        }).then(result => {
-                
-            //content will be base64 encoded
-            let rawFile = atob(result.data.content);
-            return( JSON.parse(rawFile).molecules);
-        });
-    });
-}
-
 

--- a/dist/js/githubOauth.js
+++ b/dist/js/githubOauth.js
@@ -287,7 +287,33 @@ function loadProject(projectName){
             popup.removeChild(popup.firstChild);
         }
         popup.classList.add('off');
-    }) 
+    })
+    
+}
+
+function loadProjectByID(id){
+    //Get the repo by ID
+    
+    octokit.request('GET /repositories/:id', {id}).then(result => {
+        
+        //Find out the owners info;
+        
+        var user     = result.data.owner.login;
+        var repoName = result.data.name;
+        
+        //Get the file contents
+        
+        octokit.repos.getContents({
+            owner: user,
+            repo: repoName,
+            path: 'project.maslowcreate'
+        }).then(result => {
+                
+            //content will be base64 encoded
+            let rawFile = atob(result.data.content);
+            return( JSON.parse(rawFile).molecules);
+        });
+    });
 }
 
 

--- a/dist/js/githubOauth.js
+++ b/dist/js/githubOauth.js
@@ -306,28 +306,66 @@ function exportCurrentMoleculeToGithub(molecule){
         name: name,
         description: description
     }).then(result => {
-        console.log("creating new repo");
+        console.log("creating new repo:");
+        console.log(result);
         //Once we have created the new repo we need to create a file within it to store the project in
-        currentRepoName = result.data.name;
-        var path = "project.maslowcreate";
-        var content = window.btoa("init"); // create a file with just the word "init" in it and base64 encode it
+        var repoName = result.data.name;
+        var id       = result.data.id;
+        var path     = "project.maslowcreate";
+        var content  = window.btoa("init"); // create a file with just the word "init" in it and base64 encode it
         octokit.repos.createFile({
             owner: currentUser,
-            repo: currentRepoName,
+            repo: repoName,
             path: path,
             message: "initialize repo", 
             content: content
-        })
+        }).then(result => {
+            console.log("Created: ");
+            console.log(result);
+            
+            //Save the molecule into the newly created repo
+            
+            var path = "project.maslowcreate";
+            
+            molecule.topLevel = true; //force the molecule to export in the long form as if it were the top level molecule
+            var content = window.btoa(JSON.stringify(molecule.serialize(null), null, 4)); //Convert the passed molecule object to a JSON string and then convert it to base64 encoding
+            
+            //Get the SHA for the file
+            octokit.repos.getContents({
+                owner: currentUser,
+                repo: repoName,
+                path: path
+            }).then(result => {
+                var sha = result.data.sha
+                
+                //Save the repo to the file
+                octokit.repos.updateFile({
+                    owner: currentUser,
+                    repo: repoName,
+                    path: path,
+                    message: "export Molecule", 
+                    content: content,
+                    sha: sha
+                }).then(result => {
+                    console.log("Molecule Exported!");
+                    
+                    //Replace the existing molecule now that we just exported
+                    molecule.replaceThisMoleculeWithGithub(id);
+                })
+            })
+
+        });
         
         //Update the project topics
         octokit.repos.replaceTopics({
             owner: currentUser,
-            repo: currentRepoName,
+            repo: repoName,
             names: ["maslowcreate-molecule"],
             headers: {
                 accept: 'application/vnd.github.mercy-preview+json'
             }
         })
+        
     });
 }
 

--- a/dist/js/githubOauth.js
+++ b/dist/js/githubOauth.js
@@ -92,7 +92,13 @@ function addProject(projectName){
     projectPicture.setAttribute("style", "height: 100%");
     project.appendChild(projectPicture);
     
-    var shortProjectName = document.createTextNode(projectName.substr(0,7)+"..");
+    var shortProjectName;
+    if(projectName.length > 9){
+        shortProjectName = document.createTextNode(projectName.substr(0,7)+"..");
+    }
+    else{
+        shortProjectName = document.createTextNode(projectName);
+    }
     project.setAttribute("class", "project");
     project.setAttribute("id", projectName);
     project.appendChild(shortProjectName); 

--- a/dist/js/githubOauth.js
+++ b/dist/js/githubOauth.js
@@ -291,4 +291,44 @@ function loadProject(projectName){
     
 }
 
+function exportCurrentMoleculeToGithub(molecule){
+    console.log("export current molecule to github");
+    
+    //Get name and description
+    var name = molecule.name;
+    var description = "A stand alone molecule exported from Maslow Create";
+    
+    console.log("Name: " + name);
+    console.log(molecule);
+    
+    //Create a new repo
+    octokit.repos.createForAuthenticatedUser({
+        name: name,
+        description: description
+    }).then(result => {
+        console.log("creating new repo");
+        //Once we have created the new repo we need to create a file within it to store the project in
+        currentRepoName = result.data.name;
+        var path = "project.maslowcreate";
+        var content = window.btoa("init"); // create a file with just the word "init" in it and base64 encode it
+        octokit.repos.createFile({
+            owner: currentUser,
+            repo: currentRepoName,
+            path: path,
+            message: "initialize repo", 
+            content: content
+        })
+        
+        //Update the project topics
+        octokit.repos.replaceTopics({
+            owner: currentUser,
+            repo: currentRepoName,
+            names: ["maslowcreate-molecule"],
+            headers: {
+                accept: 'application/vnd.github.mercy-preview+json'
+            }
+        })
+    });
+}
+
 

--- a/dist/js/molecules/githubmolecule.js
+++ b/dist/js/molecules/githubmolecule.js
@@ -12,8 +12,7 @@ class GitHubMolecule extends Molecule {
         
         this.setValues(values);
         
-        var moleculesList = loadProjectByID(this.projectID);
-        console.log(moleculesList);
+        this.loadProjectByID(this.projectID);
         
     }
     
@@ -29,6 +28,33 @@ class GitHubMolecule extends Molecule {
         }
         
         return clickProcessed; 
+    }
+    
+    loadProjectByID(id){
+    //Get the repo by ID
+        console.log("loading project by id");
+        octokit.request('GET /repositories/:id', {id}).then(result => {
+            
+            //Find out the owners info;
+            
+            var user     = result.data.owner.login;
+            var repoName = result.data.name;
+            
+            //Get the file contents
+            
+            octokit.repos.getContents({
+                owner: user,
+                repo: repoName,
+                path: 'project.maslowcreate'
+            }).then(result => {
+                    
+                //content will be base64 encoded
+                let rawFile = atob(result.data.content);
+                let moleculesList =  JSON.parse(rawFile).molecules;
+                
+                this.deserialize(moleculesList, moleculesList.filter((molecule) => { return molecule.topLevel == true; })[0].uniqueID);
+            });
+        });
     }
     
 }

--- a/dist/js/molecules/githubmolecule.js
+++ b/dist/js/molecules/githubmolecule.js
@@ -53,8 +53,28 @@ class GitHubMolecule extends Molecule {
                 let moleculesList =  JSON.parse(rawFile).molecules;
                 
                 this.deserialize(moleculesList, moleculesList.filter((molecule) => { return molecule.topLevel == true; })[0].uniqueID);
+                
+                this.topLevel = false;
             });
         });
+    }
+    
+    serialize(savedObject){
+        //Save this molecule.
+        
+        savedObject.molecules.push(thisAsObject);
+            
+        //Return a placeholder for this molecule
+        var object = {
+            atomType: this.atomType,
+            name: this.name,
+            x: this.x,
+            y: this.y,
+            uniqueID: this.uniqueID,
+            projectID: this.projectID
+        }
+        
+        return object;
     }
     
 }

--- a/dist/js/molecules/githubmolecule.js
+++ b/dist/js/molecules/githubmolecule.js
@@ -1,0 +1,34 @@
+class GitHubMolecule extends Molecule {
+    
+    constructor(values){
+        super(values);
+        
+        
+        this.name = "Github Molecule";
+        this.atomType = "GitHubMolecule";
+        this.topLevel = false; //a flag to signal if this node is the top level node
+        this.centerColor = "black";
+        this.projectID = 173269838;
+        
+        this.setValues(values);
+        
+        var moleculesList = loadProjectByID(this.projectID);
+        console.log(moleculesList);
+        
+    }
+    
+    doubleClick(x,y){
+        //Prevent you from being able to double click into a github molecule
+        
+        var clickProcessed = false;
+        
+        var distFromClick = distBetweenPoints(x, this.x, y, this.y);
+        
+        if (distFromClick < this.radius){
+            clickProcessed = true;
+        }
+        
+        return clickProcessed; 
+    }
+    
+}

--- a/dist/js/molecules/githubmolecule.js
+++ b/dist/js/molecules/githubmolecule.js
@@ -60,10 +60,7 @@ class GitHubMolecule extends Molecule {
     }
     
     serialize(savedObject){
-        //Save this molecule.
         
-        savedObject.molecules.push(thisAsObject);
-            
         //Return a placeholder for this molecule
         var object = {
             atomType: this.atomType,

--- a/dist/js/molecules/githubmolecule.js
+++ b/dist/js/molecules/githubmolecule.js
@@ -8,7 +8,7 @@ class GitHubMolecule extends Molecule {
         this.atomType = "GitHubMolecule";
         this.topLevel = false; //a flag to signal if this node is the top level node
         this.centerColor = "black";
-        this.projectID = 173269838;
+        this.projectID = 174292302;
         
         this.setValues(values);
         

--- a/dist/js/molecules/molecule.js
+++ b/dist/js/molecules/molecule.js
@@ -249,6 +249,8 @@ class Molecule extends Atom{
         moleculeObject.allConnectors.forEach(connector => {
             this.placeConnector(JSON.parse(connector));
         });
+        
+        this.updateCodeBlock();
     }
     
     placeAtom(newAtomObj, moleculeList, typesList){

--- a/dist/js/molecules/molecule.js
+++ b/dist/js/molecules/molecule.js
@@ -109,14 +109,18 @@ class Molecule extends Atom{
             this.createButton(valueList,this,"Load A Different Project",showProjectsToLoad)
         }
         
-        this.createButton(valueList,this,"Export To GitHub", function(){ return this.exportToGithub(this);})
+        this.createButton(valueList,this,"Export To GitHub", this.exportToGithub)
         
         return valueList;
         
     }
     
-    goToParentMolecule(){
+    
+    
+    goToParentMolecule(self){
         //Go to the parent molecule if there is one
+        
+        currentMolecule.updateCodeBlock();
         
         if(!currentMolecule.topLevel){
             currentMolecule = currentMolecule.parent; //set parent this to be the currently displayed molecule
@@ -126,6 +130,31 @@ class Molecule extends Atom{
     exportToGithub(self){
         console.log("export this  molecule to github");
         exportCurrentMoleculeToGithub(self);
+    }
+    
+    replaceThisMoleculeWithGithub(githubID){
+        console.log("replace ran");
+        console.log(githubID);
+        
+        //If we are currently inside the molecule go up one
+        // if (currentMolecule.uniqueID == this.uniqueID){
+            // this.goToParentMolecule(this);
+        // }
+        
+        //Create a new github molecule in the same spot
+        currentMolecule.placeAtom({
+            x: this.x, 
+            y: this.y, 
+            parent: currentMolecule,
+            name: this.name,
+            atomType: "GitHubMolecule",
+            projectID: githubID,
+            uniqueID: generateUniqueID()
+        }, null, availableTypes);
+        
+        //Then delete the old molecule which has been replaced
+        this.deleteNode();
+
     }
     
     setValue(newName){

--- a/dist/js/molecules/molecule.js
+++ b/dist/js/molecules/molecule.js
@@ -13,19 +13,15 @@ class Molecule extends Atom{
         
         this.setValues(values);
         
-        //Add the output
-        if (!this.topLevel){
-            
-            //Add the molecule's output
-            this.placeAtom({
-                parentMolecule: this, 
-                x: canvas.width - 50,
-                y: canvas.height/2,
-                parent: this,
-                name: "Output",
-                atomType: "Output"
-            }, null, secretTypes);
-        }
+        //Add the molecule's output
+        this.placeAtom({
+            parentMolecule: this, 
+            x: canvas.width - 50,
+            y: canvas.height/2,
+            parent: this,
+            name: "Output",
+            atomType: "Output"
+        }, null, secretTypes);
     }
     
     draw(){

--- a/dist/js/molecules/molecule.js
+++ b/dist/js/molecules/molecule.js
@@ -22,6 +22,8 @@ class Molecule extends Atom{
             name: "Output",
             atomType: "Output"
         }, null, secretTypes);
+        
+        this.updateCodeBlock();
     }
     
     draw(){
@@ -128,18 +130,17 @@ class Molecule extends Atom{
     }
     
     exportToGithub(self){
-        console.log("export this  molecule to github");
+        //Export this molecule to github
         exportCurrentMoleculeToGithub(self);
     }
     
     replaceThisMoleculeWithGithub(githubID){
-        console.log("replace ran");
         console.log(githubID);
         
-        //If we are currently inside the molecule go up one
-        // if (currentMolecule.uniqueID == this.uniqueID){
-            // this.goToParentMolecule(this);
-        // }
+        //If we are currently inside the molecule targeted for replacement, go up one
+        if (currentMolecule.uniqueID == this.uniqueID){
+            currentMolecule = this.parent;
+        }
         
         //Create a new github molecule in the same spot
         currentMolecule.placeAtom({

--- a/dist/js/molecules/molecule.js
+++ b/dist/js/molecules/molecule.js
@@ -8,6 +8,7 @@ class Molecule extends Atom{
         this.children = [];
         this.name = "Molecule";
         this.atomType = "Molecule";
+        this.centerColor = "#949294";
         this.topLevel = false; //a flag to signal if this node is the top level node
         
         this.setValues(values);
@@ -32,7 +33,7 @@ class Molecule extends Atom{
         
         //draw the circle in the middle
         c.beginPath();
-        c.fillStyle = "#949294";
+        c.fillStyle = this.centerColor;
         c.arc(this.x, this.y, this.radius/2, 0, Math.PI * 2, false);
         c.closePath();
         c.fill();
@@ -101,7 +102,7 @@ class Molecule extends Atom{
     updateSidebar(){
         //Update the side bar to make it possible to change the molecule name
         
-        var valueList = super.updateSidebar.call(this); //call the super function
+        var valueList = super.updateSidebar(); //call the super function
         
         this.createEditableValueListItem(valueList,this,"name", "Name", false);
         
@@ -111,6 +112,8 @@ class Molecule extends Atom{
         else{
             this.createButton(valueList,this,"Load A Different Project",showProjectsToLoad)
         }
+        
+        return valueList;
         
     }
     

--- a/dist/js/molecules/molecule.js
+++ b/dist/js/molecules/molecule.js
@@ -109,6 +109,8 @@ class Molecule extends Atom{
             this.createButton(valueList,this,"Load A Different Project",showProjectsToLoad)
         }
         
+        this.createButton(valueList,this,"Export To GitHub", function(){ return this.exportToGithub(this);})
+        
         return valueList;
         
     }
@@ -119,6 +121,11 @@ class Molecule extends Atom{
         if(!currentMolecule.topLevel){
             currentMolecule = currentMolecule.parent; //set parent this to be the currently displayed molecule
         }
+    }
+    
+    exportToGithub(self){
+        console.log("export this  molecule to github");
+        exportCurrentMoleculeToGithub(self);
     }
     
     setValue(newName){

--- a/dist/js/molecules/molecule.js
+++ b/dist/js/molecules/molecule.js
@@ -106,18 +106,16 @@ class Molecule extends Atom{
         
         if(!this.topLevel){
             this.createButton(valueList,this,"Go To Parent",this.goToParentMolecule);
+            
+            this.createButton(valueList,this,"Export To GitHub", this.exportToGithub)
         }
         else{
             this.createButton(valueList,this,"Load A Different Project",showProjectsToLoad)
         }
         
-        this.createButton(valueList,this,"Export To GitHub", this.exportToGithub)
-        
         return valueList;
         
     }
-    
-    
     
     goToParentMolecule(self){
         //Go to the parent molecule if there is one
@@ -152,6 +150,7 @@ class Molecule extends Atom{
             projectID: githubID,
             uniqueID: generateUniqueID()
         }, null, availableTypes);
+        
         
         //Then delete the old molecule which has been replaced
         this.deleteNode();

--- a/dist/js/molecules/prototypes.js
+++ b/dist/js/molecules/prototypes.js
@@ -761,7 +761,7 @@ class Atom {
         
         button.addEventListener(
             'mousedown',
-            functionToCall,
+            function() { functionToCall(parent); } ,
             false
         );
     }

--- a/src/index.html
+++ b/src/index.html
@@ -93,6 +93,7 @@
     <script src="/js/molecules/scale.js"></script>
     <script src="/js/molecules/intersection.js"></script>
     <script src="/js/molecules/difference.js"></script>
+    <script src="/js/molecules/githubmolecule.js"></script>
     <script src="/circular-json.js"></script>
     <script src="/js/molecules/menu.js"></script>
     <script src="/flowDraw.js"></script>


### PR DESCRIPTION
This lets you encapsulate all of the logic within a molecule and export it to github a stand alone project which can be imported and used in multiple places.

The current molecule is replaced with a place holder which loads from the newly generated github project 