### PR TITLE
Add the create a new project button back

### DIFF
--- a/src/js/githubOauth.js
+++ b/src/js/githubOauth.js
@@ -104,6 +104,9 @@ export default class GitHubModule{
                 this.projectsSpaceDiv.removeChild(this.projectsSpaceDiv.firstChild);
             }
             
+            //Add the create a new project button
+            this.addProject("New Project");
+            
             //Load projects
             var query;
             var owned;


### PR DESCRIPTION
Some earlier changes accidentally deleted the "new project" button