### PR TITLE
trigger a save of the project as soon as it is created

### DIFF
--- a/src/js/githubOauth.js
+++ b/src/js/githubOauth.js
@@ -324,6 +324,10 @@ export default class GitHubModule{
                         
                         var _this = this;
                         this.intervalTimer = setInterval(function() { _this.saveProject(); }, 30000); //Save the project regularly
+                        
+                        
+                        //Trigger a save of the project
+                        this.saveProject();
                     });
                 });
             });


### PR DESCRIPTION
To reduce the chance of ending up with a corrupted project by opening it and then closing the window before it can save