### PR TITLE
Move bill of materials handling into an atom

### DIFF
--- a/src/js/globalvariables.js
+++ b/src/js/globalvariables.js
@@ -13,6 +13,7 @@ import Equation from './molecules/equation.js'
 import Molecule from './molecules/molecule.js'
 import Input from './molecules/input.js'
 import Readme from './molecules/readme.js'
+import BillOfMaterials from './molecules/BOM.js'
 import Rotate from './molecules/rotate.js'
 import Mirror from './molecules/mirror.js'
 import GitHubMolecule from './molecules/githubmolecule.js'
@@ -26,24 +27,25 @@ class GlobalVariables{
         this.c = null
         
         this.availableTypes = {
-            circle:        {creator: Circle, atomType: "Circle"},
-            rectangle:     {creator: Rectangle, atomType: "Rectangle"},
-            shirinkwrap:   {creator: ShrinkWrap, atomType: "ShrinkWrap"},
-            translate:     {creator: Translate, atomType: "Translate"},
-            regularPolygon:{creator: RegularPolygon, atomType: "RegularPolygon"},
-            extrude:       {creator: Extrude, atomType: "Extrude"},
-            scale:         {creator: Scale, atomType: "Scale"},
-            intersection:  {creator: Intersection, atomType: "Intersection"},
-            difference:    {creator: Difference, atomType: "Difference"},
-            costant:       {creator: Constant, atomType: "Constant"},
-            equation:      {creator: Equation, atomType: "Equation"},
-            molecule:      {creator: Molecule, atomType: "Molecule"},
-            input:         {creator: Input, atomType: "Input"},
-            readme:        {creator: Readme, atomType: "Readme"},
-            rotate:        {creator: Rotate, atomType: "Rotate"},
-            mirror:        {creator: Mirror, atomType: "Mirror"},
-            githubmolecule:{creator: GitHubMolecule, atomType: "GitHubMolecule"},
-            union:         {creator: Union, atomType: "Union"}
+            circle:             {creator: Circle, atomType: "Circle"},
+            rectangle:          {creator: Rectangle, atomType: "Rectangle"},
+            shirinkwrap:        {creator: ShrinkWrap, atomType: "ShrinkWrap"},
+            translate:          {creator: Translate, atomType: "Translate"},
+            regularPolygon:     {creator: RegularPolygon, atomType: "RegularPolygon"},
+            extrude:            {creator: Extrude, atomType: "Extrude"},
+            scale:              {creator: Scale, atomType: "Scale"},
+            intersection:       {creator: Intersection, atomType: "Intersection"},
+            difference:         {creator: Difference, atomType: "Difference"},
+            costant:            {creator: Constant, atomType: "Constant"},
+            equation:           {creator: Equation, atomType: "Equation"},
+            molecule:           {creator: Molecule, atomType: "Molecule"},
+            input:              {creator: Input, atomType: "Input"},
+            readme:             {creator: Readme, atomType: "Readme"},
+            billOfMaterials:    {creator: BillOfMaterials, atomType: "Bill Of Materials"},
+            rotate:             {creator: Rotate, atomType: "Rotate"},
+            mirror:             {creator: Mirror, atomType: "Mirror"},
+            githubmolecule:     {creator: GitHubMolecule, atomType: "GitHubMolecule"},
+            union:              {creator: Union, atomType: "Union"}
         }
 
         this.secretTypes = {

--- a/src/js/molecules/BOM.js
+++ b/src/js/molecules/BOM.js
@@ -1,0 +1,55 @@
+import Atom from '../prototypes/atom'
+import GlobalVariables from '../globalvariables'
+
+
+export default class BillOfMaterials extends Atom{
+    constructor(values){
+        super(values);
+        
+        this.codeBlock = "";
+        this.atomType = "Bill Of Materials";
+        this.type = "billOfMaterials";
+        this.name = "Bill Of Materials";
+        this.radius = 20;
+        
+        this.setValues(values);
+    }
+    
+    updateSidebar(){
+        //updates the sidebar to display information about this node
+        
+        var valueList = super.updateSidebar(); //call the super function
+        
+        
+    }
+    
+    draw() {
+        
+        super.draw(); //Super call to draw the rest
+        
+        
+        GlobalVariables.c.beginPath();
+        GlobalVariables.c.fillStyle = "#949294";
+        GlobalVariables.c.font = "30px Work Sans Bold";
+        GlobalVariables.c.fillText('B', this.x - (this.radius/2.2), this.y + (this.radius/2.1));
+        GlobalVariables.c.fill();
+        GlobalVariables.c.closePath();
+        
+    }
+    
+    requestReadme(){
+        //request any contributions from this atom to the readme
+        
+        return [this.readmeText];
+    }
+    
+    serialize(values){
+        //Save the readme text to the serial stream
+        var valuesObj = super.serialize(values);
+        
+        valuesObj.readmeText = this.readmeText;
+        
+        return valuesObj;
+        
+    }
+}

--- a/src/js/molecules/BOM.js
+++ b/src/js/molecules/BOM.js
@@ -1,5 +1,6 @@
 import Atom from '../prototypes/atom'
 import GlobalVariables from '../globalvariables'
+import BOMEntry from '../BOM'
 
 
 export default class BillOfMaterials extends Atom{
@@ -12,6 +13,8 @@ export default class BillOfMaterials extends Atom{
         this.name = "Bill Of Materials";
         this.radius = 20;
         
+        this.BOMlist = [];
+        
         this.setValues(values);
     }
     
@@ -20,7 +23,7 @@ export default class BillOfMaterials extends Atom{
         
         var valueList = super.updateSidebar(); //call the super function
         
-        
+        this.createBOM(valueList, this, this.BOMlist);
     }
     
     draw() {
@@ -43,11 +46,53 @@ export default class BillOfMaterials extends Atom{
         return [this.readmeText];
     }
     
+    requestBOM(){
+        //Placeholder
+        return this.BOMlist;
+    }
+    
+    createBOM(list,parent,BOMlist){
+        //aBOMEntry = new bomEntry;
+        
+        
+        list.appendChild(document.createElement('br'));
+        list.appendChild(document.createElement('br'));
+        
+        var div = document.createElement("h3");
+        div.setAttribute("style","text-align:center;");
+        list.appendChild(div);
+        var valueText = document.createTextNode("Bill Of Materials");
+        div.appendChild(valueText);
+        
+        var x = document.createElement("HR");
+        list.appendChild(x);
+        
+        this.BOMlist.forEach(bomItem => {
+            this.createEditableValueListItem(list,bomItem,"BOMitemName", "Item", false)
+            this.createEditableValueListItem(list,bomItem,"numberNeeded", "Number", true)
+            this.createEditableValueListItem(list,bomItem,"costUSD", "Price", true)
+            this.createEditableValueListItem(list,bomItem,"source", "Source", false)
+            var x = document.createElement("HR");
+            list.appendChild(x);
+        });
+        
+        this.createButton(list,parent,"Add BOM Entry",(e) => {
+           this.addBOMEntry();
+        });
+    }
+    
+    addBOMEntry(){
+        console.log("add bom entry ran");
+        this.BOMlist.push(new BOMEntry());
+        
+        this.updateSidebar();
+    }
+    
     serialize(values){
         //Save the readme text to the serial stream
         var valuesObj = super.serialize(values);
         
-        valuesObj.readmeText = this.readmeText;
+        valuesObj.BOMlist = this.BOMlist;
         
         return valuesObj;
         

--- a/src/js/molecules/BOM.js
+++ b/src/js/molecules/BOM.js
@@ -52,8 +52,6 @@ export default class BillOfMaterials extends Atom{
     }
     
     createBOM(list,parent,BOMlist){
-        //aBOMEntry = new bomEntry;
-        
         
         list.appendChild(document.createElement('br'));
         list.appendChild(document.createElement('br'));

--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -140,11 +140,30 @@ export default class Molecule extends Atom{
         }
         
                 
-        //this.createBOM(valueList,this,this.BOMlist);
+        this.displaySimpleBOM(valueList);
         
         return valueList;
         
     }
+    
+    displaySimpleBOM(list){
+        list.appendChild(document.createElement('br'));
+        list.appendChild(document.createElement('br'));
+        
+        var div = document.createElement("h3");
+        div.setAttribute("style","text-align:center;");
+        list.appendChild(div);
+        var valueText = document.createTextNode("Bill Of Materials");
+        div.appendChild(valueText);
+        
+        var x = document.createElement("HR");
+        list.appendChild(x);
+        
+        this.requestBOM().forEach(bomEntry => {
+            this.createNonEditableValueListItem(list,bomEntry,"numberNeeded", bomEntry.BOMitemName, false)
+        });
+    }
+        
     
     goToParentMolecule(self){
         //Go to the parent molecule if there is one

--- a/src/js/prototypes/atom.js
+++ b/src/js/prototypes/atom.js
@@ -57,6 +57,7 @@ export default class Atom {
         
         GlobalVariables.c.beginPath();
         GlobalVariables.c.fillStyle = this.color;
+        GlobalVariables.c.font = "10px Work Sans";
         //make it imposible to draw atoms too close to the edge
         //not sure what x left margin should be because if it's too close it would cover expanded text
         var canvasFlow = document.querySelector('#flow-canvas');

--- a/src/js/prototypes/atom.js
+++ b/src/js/prototypes/atom.js
@@ -1,6 +1,5 @@
 import AttachmentPoint from './attachmentpoint'
 import GlobalVariables from '../globalvariables'
-import BOMEntry from '../BOM'
 
 export default class Atom {
 
@@ -20,7 +19,6 @@ export default class Atom {
         this.codeBlock = "";
         this.defaultCodeBlock = "";
         this.isMoving = false;
-        this.BOMlist = [];
         
         for(var key in values) {
             this[key] = values[key];
@@ -279,30 +277,15 @@ export default class Atom {
             x: this.x,
             y: this.y,
             uniqueID: this.uniqueID,
-            ioValues: ioValues,
-            BOMlist: this.BOMlist
+            ioValues: ioValues
         }
         
         return object;
     }
     
     requestBOM(){
-        //Request any contributions from this atom to the BOM
-        
-        
-        //Find the number of things attached to this output
-        var numberOfThisInstance = 1;
-        this.children.forEach(io => {
-            if(io.type == "output" && io.connectors.length != 0){
-                numberOfThisInstance = io.connectors.length;
-            }
-        });
-        //And scale up the total needed by that number
-        this.BOMlist.forEach(bomItem => {
-            bomItem.totalNeeded = numberOfThisInstance*bomItem.numberNeeded;
-        });
-        
-        return this.BOMlist;
+        //Placeholder
+        return [];
     }
     
     requestReadme(){
@@ -521,47 +504,4 @@ export default class Atom {
         );
     }
 
-    createBOM(list,parent,BOMlist){
-        //aBOMEntry = new bomEntry;
-        
-        
-        list.appendChild(document.createElement('br'));
-        list.appendChild(document.createElement('br'));
-        
-        var div = document.createElement("h3");
-        div.setAttribute("style","text-align:center;");
-        list.appendChild(div);
-        var valueText = document.createTextNode("Bill Of Materials");
-        div.appendChild(valueText);
-        
-        var x = document.createElement("HR");
-        list.appendChild(x);
-        
-        this.requestBOM().forEach(bomItem => {
-            if(this.BOMlist.indexOf(bomItem) != -1){ //If the bom item is from this molecule
-                this.createEditableValueListItem(list,bomItem,"BOMitemName", "Item", false)
-                this.createEditableValueListItem(list,bomItem,"numberNeeded", "Number", true)
-                this.createEditableValueListItem(list,bomItem,"costUSD", "Price", true)
-                this.createEditableValueListItem(list,bomItem,"source", "Source", false)
-            }
-            else{
-                this.createNonEditableValueListItem(list,bomItem,"BOMitemName", "Item", false)
-                this.createNonEditableValueListItem(list,bomItem,"totalNeeded", "Number", true)
-                this.createNonEditableValueListItem(list,bomItem,"costUSD", "Price", true)
-                this.createNonEditableValueListItem(list,bomItem,"source", "Source", false)
-            }
-            var x = document.createElement("HR");
-            list.appendChild(x);
-        });
-        
-        this.createButton(list,parent,"Add BOM Entry", this.addBOMEntry);
-    }
-    
-    addBOMEntry(self){
-        console.log("add a bom entry");
-        
-        self.BOMlist.push(new BOMEntry());
-        
-        self.updateSidebar();
-    }
 }

--- a/src/js/prototypes/attachmentpoint.js
+++ b/src/js/prototypes/attachmentpoint.js
@@ -39,6 +39,7 @@ export default class AttachmentPoint {
 
         var txt = this.name;
         var textWidth = GlobalVariables.c.measureText(txt).width;
+        GlobalVariables.c.font = "10px Work Sans";
         var bubbleColor = "#008080";
         var scaleRadiusDown = this.radius*.7;
         var halfRadius = this.radius*.5;


### PR DESCRIPTION
You can now add a bill of materials to any molecule by placing a bill of materials atom within it. This is much cleaner than having every molecule have a bill of materials by default