### PR TITLE
Stop using stringify to compress atoms to a single line

### DIFF
--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -252,7 +252,7 @@ export default class Molecule extends Atom{
         
         this.nodesOnTheScreen.forEach(atom => {
             //Store a represnetation of the atom
-            allAtoms.push(JSON.stringify(atom.serialize(savedObject)));
+            allAtoms.push(atom.serialize(savedObject));
             //Store a representation of the atom's connectors
             atom.children.forEach(attachmentPoint => {
                 if(attachmentPoint.type == "output"){
@@ -291,7 +291,7 @@ export default class Molecule extends Atom{
             
             //Place the atoms
             moleculeObject.allAtoms.forEach(atom => {
-                this.placeAtom(JSON.parse(atom), moleculeList, GlobalVariables.availableTypes);
+                this.placeAtom(atom, moleculeList, GlobalVariables.availableTypes);
             });
             
             //reload the molecule object to prevent persistence issues
@@ -300,7 +300,7 @@ export default class Molecule extends Atom{
             //Place the connectors FIXME: This is being saved into the object twice now that we are saving everything from the main object so the variable name should be changed
             this.savedConnectors = moleculeObject.allConnectors; //Save a copy of the connectors so we can use them later if we want
             this.savedConnectors.forEach(connector => {
-                this.placeConnector(JSON.parse(connector));
+                this.placeConnector(connector);
             });
             
             this.setValues([]);//Call set values again with an empty list to trigger loading of IO values from memory

--- a/src/js/prototypes/atom.js
+++ b/src/js/prototypes/atom.js
@@ -65,7 +65,7 @@ export default class Atom {
         GlobalVariables.c.fillStyle = this.color;
         GlobalVariables.c.font = "10px Work Sans";
 
-        //make it imposible to draw atoms too close to the edge
+        //make it impossible to draw atoms too close to the edge
         //not sure what x left margin should be because if it's too close it would cover expanded text
         var canvasFlow = document.querySelector('#flow-canvas');
         if (this.scaledX < this.scaledRadius*3){

--- a/src/js/prototypes/connector.js
+++ b/src/js/prototypes/connector.js
@@ -91,7 +91,7 @@ export default class Connector {
                 ap1ID: this.attachmentPoint1.parentMolecule.uniqueID,
                 ap2ID: this.attachmentPoint2.parentMolecule.uniqueID
             }
-            return JSON.stringify(object);
+            return object;
         }
     }
     


### PR DESCRIPTION
It would be nice if atoms could be compressed to a single line each, but it's not worth the sacrifice of not being able to use standard json. Down the road I would like to switch to manually adding the spacing into the file.

@alzatin This change will make it so we can't open any projects created before this point 😢 